### PR TITLE
Change Tab Expand image file path to work on linux and windows

### DIFF
--- a/src/main/java/halosuit/gui/ExpandableTab.java
+++ b/src/main/java/halosuit/gui/ExpandableTab.java
@@ -14,7 +14,7 @@ import javax.swing.JTabbedPane;
 public class ExpandableTab extends JPanel {
 	
 	
-	private JButton expandButton = new JButton(new ImageIcon("src\\main\\resources\\images\\plus symbol.png"));
+	private JButton expandButton = new JButton(new ImageIcon("src//main//resources//images//plus symbol.png"));
 	private JLabel title = null;
 	
 	public ExpandableTab(String title, JTabbedPane tabbedPane) {


### PR DESCRIPTION
The file path accessing the expand tab resource was using
the windows only path specifier "\\". This changes the
path to use "//" which works on both linux and windows.
